### PR TITLE
FOGL-9791:Fixed memory leaks in test cases

### DIFF
--- a/tests/test_expression.cpp
+++ b/tests/test_expression.cpp
@@ -17,6 +17,7 @@ extern "C" {
 	void plugin_ingest(void *handle,
                    READINGSET *readingSet);
 	PLUGIN_HANDLE plugin_init(ConfigCategory& config);
+	void plugin_shutdown(PLUGIN_HANDLE handle);
 	bool plugin_eval(PLUGIN_HANDLE handle,
                  const string& assetValues);
 };
@@ -36,6 +37,7 @@ TEST(EXPRESSION, NoTrigger)
 
 	bool result = plugin_eval(handle, values);
 	ASSERT_EQ(result, false);
+	plugin_shutdown(handle);
 }
 
 TEST(EXPRESSION, Trigger)
@@ -53,6 +55,7 @@ TEST(EXPRESSION, Trigger)
 
 	bool result = plugin_eval(handle, values);
 	ASSERT_EQ(result, true);
+	plugin_shutdown(handle);
 }
 
 TEST(EXPRESSION, FloatNoTrigger)
@@ -70,6 +73,7 @@ TEST(EXPRESSION, FloatNoTrigger)
 
 	bool result = plugin_eval(handle, values);
 	ASSERT_EQ(result, false);
+	plugin_shutdown(handle);
 }
 
 TEST(EXPRESSION, FloatTrigger)
@@ -87,6 +91,7 @@ TEST(EXPRESSION, FloatTrigger)
 
 	bool result = plugin_eval(handle, values);
 	ASSERT_EQ(result, true);
+	plugin_shutdown(handle);
 }
 
 TEST(EXPRESSION, DifferentAsset)
@@ -104,4 +109,5 @@ TEST(EXPRESSION, DifferentAsset)
 
 	bool result = plugin_eval(handle, values);
 	ASSERT_EQ(result, false);
+	plugin_shutdown(handle);
 }


### PR DESCRIPTION
Valgrind report
```
==74433== LEAK SUMMARY:
==74433==    definitely lost: 0 bytes in 0 blocks
==74433==    indirectly lost: 0 bytes in 0 blocks
==74433==      possibly lost: 320 bytes in 1 blocks
==74433==    still reachable: 912 bytes in 4 blocks
==74433==         suppressed: 0 bytes in 0 blocks
==74433== Reachable blocks (those to which a pointer was found) are not shown.
```